### PR TITLE
Feature/security checks

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: dhis2-sre/gha-workflows/.github/workflows/instance-manager.yaml@v0.6.0
+    uses: dhis2-sre/gha-workflows/.github/workflows/instance-manager.yaml@v0.8.0
     with:
       PROCESS_NAME: go-api-gateway
       POD_NAME: go-api-gateway

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,24 @@
+fail_fast: true
+
 default_install_hook_types:
   - pre-commit
   - commit-msg
 repos:
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: 754b74671bbdd30059a778d480342a037aff9cd7
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
     hooks:
       - id: go-imports
       - id: go-mod-tidy
+      - id: go-sec-repo-mod
+
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.45.2
+    rev: v1.51.1
     hooks:
       - id: golangci-lint
+        args:
+          - "--timeout=3m"
+          - "--enable=gocritic"
+
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.24.0
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS build
+FROM golang:1.20-alpine3.17 AS build
 ARG REFLEX_VERSION=v0.3.1
 RUN apk add gcc musl-dev git
 WORKDIR /src
@@ -8,7 +8,7 @@ RUN go mod download -x
 COPY . .
 RUN go build -o /app/go-api-gateway -ldflags "-s -w" ./cmd/serve
 
-FROM alpine:3.15
+FROM alpine:3.17
 RUN apk --no-cache -U upgrade
 WORKDIR /app
 COPY --from=build /app/go-api-gateway .

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/dhis2-sre/go-api-gateway/internal/gateway"
 	"github.com/dhis2-sre/go-api-gateway/internal/health"
@@ -32,8 +33,15 @@ func main() {
 	printRules(router.Rules)
 
 	port := config.ServerPort
+	server := &http.Server{
+		Addr:              ":" + port,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
 	log.Println("Listening on port: " + port)
-	log.Fatal(http.ListenAndServe(":"+port, nil))
+	err = server.ListenAndServe()
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func printRules(rules gateway.Rules) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhis2-sre/go-api-gateway
 
-go 1.18
+go 1.20
 
 require (
 	github.com/didip/tollbooth/v6 v6.1.2

--- a/internal/gateway/handler_test.go
+++ b/internal/gateway/handler_test.go
@@ -61,7 +61,6 @@ func TestHandler(t *testing.T) {
 
 func TestMaxMultipart(t *testing.T) {
 	// TODO:
-	return
 	/*
 		expected := http.StatusOK
 


### PR DESCRIPTION
While running the security checks I got the below error

    G114 (CWE-676): Use of net/http serve function that has no support for setting timeouts (Confidence: HIGH, Severity: MEDIUM)

A bit of googling let me to [this](https://deepsource.io/directory/analyzers/go/issues/GO-S2114). Since it's fairly easy to implement I went ahead and did so. A bit more googling let me to [this](https://github.com/valyala/goloris) which I've used to test.

I've been running it for... Idk, more than an hour. The only thing which seems to be affected is the Nginx ingress controller which slowly grows to a bit more than 1GB of memory before (I assume) dropping all the connections. Then the pattern repeats itself.
I targeted http://im.dev.test.c.dhis2.org/ which stays functional the entire time allowing me to deploy instances with no delay. This might not be the most thorough testing but I doubt that we're affected and should the future show differently, I'd say we deal with it then.